### PR TITLE
Fix issue with segfault when rendering on a separate thread (#40)

### DIFF
--- a/Source/Modules/app_view_models/Edit/ItemList/EditItemListViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/ItemList/EditItemListViewModel.cpp
@@ -53,13 +53,6 @@ void EditItemListViewModel::handleAsyncUpdate() {
     }
 }
 
-void EditItemListViewModel::valueTreePropertyChanged(
-    juce::ValueTree &treeWhosePropertyHasChanged,
-    const juce::Identifier &property) {
-    if (childIdentifiersOfInterest.contains(
-            treeWhosePropertyHasChanged.getType()))
-        markAndUpdate(shouldUpdateItems);
-}
 void EditItemListViewModel::valueTreeChildAdded(
     juce::ValueTree &parentTree, juce::ValueTree &childWhichHasBeenAdded) {
     if (parentTree == stateToListenToForChildChanges) {

--- a/Source/Modules/app_view_models/Edit/ItemList/EditItemListViewModel.h
+++ b/Source/Modules/app_view_models/Edit/ItemList/EditItemListViewModel.h
@@ -42,8 +42,7 @@ class EditItemListViewModel : public juce::ValueTree::Listener,
     juce::ListenerList<Listener> listeners;
 
     void handleAsyncUpdate() override;
-    void valueTreePropertyChanged(juce::ValueTree &treeWhosePropertyHasChanged,
-                                  const juce::Identifier &property) override;
+
     void valueTreeChildAdded(juce::ValueTree &parentTree,
                              juce::ValueTree &childWhichHasBeenAdded) override;
     void valueTreeChildRemoved(juce::ValueTree &parentTree,

--- a/Source/Views/Edit/EditTabBarView.cpp
+++ b/Source/Views/Edit/EditTabBarView.cpp
@@ -148,11 +148,8 @@ void EditTabBarView::renderButtonReleased() {
         for (auto i = 0; i < tracktion_engine::getAllTracks(edit).size(); i++)
             tracksToDo.setBit(i);
 
-        // TODO: Fix seg fault when rendering on separate thread.
-        // Something to do with the master level measurer in the mixer view (and
-        // thread safety I assume) ...
         tracktion_engine::Renderer::renderToFile(
-            "Render", renderFile, edit, range, tracksToDo, true, {}, false);
+            "Render", renderFile, edit, range, tracksToDo, true, {}, true);
         juce::Logger::writeToLog("Render complete!");
         messageBox.setMessage("Render Complete!");
         // must call resized so message box width is updated to fit text


### PR DESCRIPTION
Fix issue with segfault when rendering on a separate thread with master track level meter


